### PR TITLE
Upgrade golang version to 1.8

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -48,7 +48,7 @@ ifeq ($(GOOS),darwin)
 	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)
 endif
 
-GO_VERSION ?= 1.4.2
+GO_VERSION ?= 1.8
 
 ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
 	GOROOT := $(shell go env GOROOT)


### PR DESCRIPTION
ran into the following issue when running `make`:

```
Go version 1.4.2 required but not found in PATH.
About to download and install go1.4.2 to /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2
Abort now if you want to manually install it system-wide instead.

mkdir -p /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2
curl -L https://golang.org/dl/go1.4.2.linux-amd64.tar.gz | tar -C /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2 --strip 1 -xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    87  100    87    0     0    472      0 --:--:-- --:--:-- --:--:--   472
100 59.5M  100 59.5M    0     0  15.7M      0  0:00:03  0:00:03 --:--:-- 18.2M
mkdir -p /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/gopath/src/github.com/prometheus/
ln -s /home/user/tmp/untitled-snippet/zookeeper_exporter /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/gopath/src/github.com/prometheus/zookeeper_exporter
GOROOT=/home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2 GOPATH=/home/user/tmp/untitled-snippet/zookeeper_exporter/.build/gopath /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2/bin/go get -d
touch dependencies-stamp
GOROOT=/home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2 GOPATH=/home/user/tmp/untitled-snippet/zookeeper_exporter/.build/gopath /home/user/tmp/untitled-snippet/zookeeper_exporter/.build/go1.4.2/bin/go build  -o zookeeper_exporter
# github.com/prometheus/client_golang/prometheus
.build/gopath/src/github.com/prometheus/client_golang/prometheus/go_collector.go:226: ms.GCCPUFraction undefined (type *runtime.MemStats has no field or method GCCPUFraction)
Makefile.COMMON:95: recipe for target 'zookeeper_exporter' failed
make: *** [zookeeper_exporter] Error 2
```

Upgrading GO_VERSION seems to fix the issue
